### PR TITLE
TestSuiteStartedEvent.Name gets a default value.

### DIFF
--- a/AllureCSharpCommons/Events/TestSuiteStartedEvent.cs
+++ b/AllureCSharpCommons/Events/TestSuiteStartedEvent.cs
@@ -9,7 +9,7 @@ namespace AllureCSharpCommons.Events
         public TestSuiteStartedEvent(string uid, string name)
         {
             Uid = uid;
-            Name = name;
+            Name = (name != null) ? name : string.Empty;
         }
 
         public override void Process(testsuiteresult context)


### PR DESCRIPTION
When generating an xml with [AllowEmptySuites](https://github.com/allure-framework/allure-csharp-commons/blob/master/AllureCSharpCommons/AllureConfig.cs#L11) set to true, the resulting xml doesn't have a 'name' element which is [required by the allure schema](https://github.com/allure-framework/allure-core/blob/master/allure-model/src/main/resources/allure.xsd#L11).

I've added a default value of String.Empty so the resulting xml after serialization will have a 'name' element and pass the schema validation.

Note: the resulting XML without the change still generates a valid allure report, it just doesn't pass the schema validation.
