### PR TITLE
Fixed XmlWriterSettings being used before properties were set.

### DIFF
--- a/AllureCSharpCommons/Utils/AllureResultsUtils.cs
+++ b/AllureCSharpCommons/Utils/AllureResultsUtils.cs
@@ -20,9 +20,14 @@ namespace AllureCSharpCommons.Utils
 
         private static readonly Object _serializerLock = new Object();
         private static XmlSerializer _serializer;
-        
-        private static XmlWriterSettings _xmlWriterSettings;
-        
+
+        private static XmlWriterSettings _xmlWriterSettings = new XmlWriterSettings {
+            Encoding = new UTF8Encoding(false, true),
+            CloseOutput = true,
+            OmitXmlDeclaration = false,
+            Indent = true
+        };
+
         private static XmlSerializer Serializer
         {
             get
@@ -32,13 +37,7 @@ namespace AllureCSharpCommons.Utils
                     lock (_serializerLock)
                     {
                         if (_serializer == null)
-                        {
-                            _xmlWriterSettings = new XmlWriterSettings();
-                            _xmlWriterSettings.Encoding = new UTF8Encoding(false, true);
-                            _xmlWriterSettings.CloseOutput = true;
-                            _xmlWriterSettings.OmitXmlDeclaration = false;
-                            _xmlWriterSettings.Indent = true;
-                        
+                        {                        
                             _serializer = new XmlSerializer(typeof(testsuiteresult));
                         }
                     }


### PR DESCRIPTION
The _xmlWriterSettings member was being accessed in the method SaveToFile inside the AllureResultsUtils class before the Serializer was initialized (inside the using block) as a result the first time Serialize was called it was using the XmlWriterSettings with default settings because the XmlWriter.Create might have copied some of them.
By moving the initialization of the XmlWriterSettings to the static member it will be initialized in the static constructor before anyone else using it.
We changed the lazy initialization to an eager one but I didn't think it will be a problem in this case considering there is no "heavy lifting" involved.